### PR TITLE
Pass switch_mac as required, rather than during creation of API

### DIFF
--- a/tplink_ess_lib/__init__.py
+++ b/tplink_ess_lib/__init__.py
@@ -49,7 +49,7 @@ class tplink_ess:
 
         switches = []
         with Network(self._host_mac) as net:
-            net.send(Protocol.DISCOVERY, {})
+            net.send(Network.BROADCAST_MAC, Protocol.DISCOVERY, {})
             while True:
                 try:
                     header, payload = net.receive()
@@ -64,8 +64,8 @@ class tplink_ess:
             _LOGGER.error("MAC address missing.")
             raise MissingMac
 
-        with Network(mac=self._host_mac, switch_mac=switch_mac) as net:
-            header, payload = net.query(Protocol.GET, [(Protocol.tp_ids[action], b'')])
+        with Network(host_mac=self._host_mac) as net:
+            header, payload = net.query(switch_mac, Protocol.GET, [(Protocol.tp_ids[action], b'')])
             return self.parse_query_response(payload)
 
 

--- a/tplink_ess_lib/__init__.py
+++ b/tplink_ess_lib/__init__.py
@@ -11,6 +11,26 @@ _LOGGER = logging.getLogger(__name__)
 class tplink_ess:
     """Represent a tplink ess switch."""
 
+    result_field_lookup = {
+        'Status': {
+            0: 'Enabled',
+            1: 'Disabled',
+        },
+        'Link Status': {
+            0: 'Link Down',
+            1: 'AUTO',
+            2: 'MH10',
+            3: 'MF10',
+            4: 'MH100',
+            5: '100Full',
+            6: '1000Full',
+        }
+    }
+
+    result_type_fields = {
+        'stats': ('Port', 'Status', 'Link Status', 'TxGoodPkt', 'TxBadPkt', 'RxGoodPkt', 'RxBadPkt')
+    }
+
     def __init__(
         self, host_mac: str = "", user: str = "", pwd: str = "", switch_mac = "",
     ) -> None:
@@ -38,6 +58,17 @@ class tplink_ess:
                     break
         return switches
 
+    async def query(self, switch_mac: str, action: str) -> dict:
+        """send a query to a specific switch and return the results as a dict"""
+        if not self._host_mac:
+            _LOGGER.error("MAC address missing.")
+            raise MissingMac
+
+        with Network(mac=self._host_mac, switch_mac=switch_mac) as net:
+            header, payload = net.query(Protocol.GET, [(Protocol.tp_ids[action], b'')])
+            return self.parse_query_response(payload)
+
+
     async def update_data(self) -> dict:
         """Refresh switch data."""
         try:
@@ -63,4 +94,13 @@ class tplink_ess:
             type_id, type_name, data = item
             output[type_name] = data
         _LOGGER.debug("Payload parse: %s", output)
+        return output
+
+    def parse_query_response(self, payload) -> list[dict]:
+        """Parse a list of records of the same type into a list of dicts"""
+        output = []
+        for type_id, type_name, data in payload:
+            if fields := self.result_type_fields.get(type_name):
+                data = {k: self.result_field_lookup.get(k, {}).get(v, v) for k, v in zip(fields, data)}
+            output.append(data)
         return output

--- a/tplink_ess_lib/__init__.py
+++ b/tplink_ess_lib/__init__.py
@@ -11,7 +11,7 @@ _LOGGER = logging.getLogger(__name__)
 class tplink_ess:
     """Represent a tplink ess switch."""
 
-    result_field_lookup = {
+    RESULT_FIELD_LOOKUP = {
         'Status': {
             0: 'Enabled',
             1: 'Disabled',
@@ -27,7 +27,7 @@ class tplink_ess:
         }
     }
 
-    result_type_fields = {
+    RESULT_TYPE_FIELDS = {
         'stats': ('Port', 'Status', 'Link Status', 'TxGoodPkt', 'TxBadPkt', 'RxGoodPkt', 'RxBadPkt')
     }
 
@@ -53,7 +53,7 @@ class tplink_ess:
             while True:
                 try:
                     header, payload = net.receive()
-                    switches.append(self.parse_payload(payload))
+                    switches.append(self.parse_discovery_response(payload))
                 except ConnectionProblem:
                     break
         return switches
@@ -82,11 +82,11 @@ class tplink_ess:
 
         for action in actions:
             header, payload = net.query(Protocol.GET, [(actions[action], b"")])
-            self._data[action] = self.parse_payload(payload)
+            self._data[action] = self.parse_discovery_response(payload)
 
         return self._data
 
-    def parse_payload(self, payload) -> dict:
+    def parse_discovery_response(self, payload) -> dict:
         """Parse the payload into a dict."""
         _LOGGER.debug("Payload in: %s", payload)
         output = {}
@@ -100,7 +100,7 @@ class tplink_ess:
         """Parse a list of records of the same type into a list of dicts"""
         output = []
         for type_id, type_name, data in payload:
-            if fields := self.result_type_fields.get(type_name):
-                data = {k: self.result_field_lookup.get(k, {}).get(v, v) for k, v in zip(fields, data)}
+            if fields := tplink_ess.RESULT_TYPE_FIELDS.get(type_name):
+                data = {k: tplink_ess.RESULT_FIELD_LOOKUP.get(k, {}).get(v, v) for k, v in zip(fields, data)}
             output.append(data)
         return output

--- a/tplink_ess_lib/network.py
+++ b/tplink_ess_lib/network.py
@@ -55,7 +55,7 @@ class Network:
             except Exception as err:
                 _LOGGER.error("Problem creating listener: %s", err)
                 raise InterfaceProblem
-            self.rs.settimeout(2)
+            self.rs.settimeout(10)
 
     def __enter__(self):
         return self

--- a/tplink_ess_lib/network.py
+++ b/tplink_ess_lib/network.py
@@ -25,27 +25,17 @@ class MissingMac(Exception):
 class Network:
 
     BROADCAST_ADDR = "255.255.255.255"
+    BROADCAST_MAC = "00:00:00:00:00:00"
     UDP_SEND_TO_PORT = 29808
     UDP_RECEIVE_FROM_PORT = 29809
 
-    def __init__(self, mac=None, switch_mac="00:00:00:00:00:00"):
-
-        self.switch_mac = switch_mac
-        self.host_mac = mac
-
+    def __init__(self, host_mac):
+        self.host_mac = host_mac
         if self.host_mac is None:
             raise MissingMac
         else:
             self.sequence_id = random.randint(0, 1000)
-
-            self.header = Protocol.header["blank"].copy()
-            self.header.update(
-                {
-                    "sequence_id": self.sequence_id,
-                    "host_mac": mac_to_bytes(self.host_mac),
-                    "switch_mac": mac_to_bytes(self.switch_mac),
-                }
-            )
+            self.token_id = None
 
             # Sending socket
             self.ss = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
@@ -65,7 +55,7 @@ class Network:
             except Exception as err:
                 _LOGGER.error("Problem creating listener: %s", err)
                 raise InterfaceProblem
-            self.rs.settimeout(10)
+            self.rs.settimeout(2)
 
     def __enter__(self):
         return self
@@ -73,18 +63,25 @@ class Network:
     def __exit__(self, exc_type, exc_value, exc_tb):
         self.rs.close()
 
-    def send(self, op_code, payload):
+    def send(self, switch_mac, op_code, payload):
         self.sequence_id = (self.sequence_id + 1) % 1000
-        self.header.update(
+
+        header = Protocol.header["blank"].copy()
+        header.update(
             {
                 "sequence_id": self.sequence_id,
+                "host_mac": mac_to_bytes(self.host_mac),
+                "switch_mac": mac_to_bytes(switch_mac),
                 "op_code": op_code,
             }
         )
-        packet = Protocol.assemble_packet(self.header, payload)
-        _LOGGER.debug("Sending Packet: " + packet.hex())
+        if self.token_id:
+            header["token_id"] = self.token_id
+
+        packet = Protocol.assemble_packet(header, payload)
+        _LOGGER.debug("Sending Packet to %s: %s", switch_mac, packet.hex())
         packet = Protocol.encode(packet)
-        _LOGGER.debug("Sending Header:  " + str(self.header))
+        _LOGGER.debug("Sending Header:  " + str(header))
         _LOGGER.debug("Sending Payload: " + str(payload))
 
         # Send packet
@@ -101,7 +98,11 @@ class Network:
             ), Protocol.interpret_payload(payload)
             _LOGGER.debug("Received Header:  " + str(header))
             _LOGGER.debug("Received Payload: " + str(payload))
-            self.header["token_id"] = header["token_id"]
+            # TODO: check sequence_id
+            # TODO: check host_mac
+            # TODO: not duplicates?
+            # self.header["token_id"] = header["token_id"]
+            self.token_id = header["token_id"]
             return header, payload
         else:
             raise ConnectionProblem()
@@ -115,8 +116,8 @@ class Network:
             return False
         return data
 
-    def query(self, op_code, payload):
-        self.send(op_code, payload)
+    def query(self, switch_mac, op_code, payload):
+        self.send(switch_mac, op_code, payload)
         header, payload = self.receive()
         return header, payload
 
@@ -126,12 +127,12 @@ class Network:
             (Protocol.get_id("password"), password.encode("ascii") + b"\x00"),
         ]
 
-    def login(self, username, password):
-        self.query(Protocol.GET, [(Protocol.get_id("get_token_id"), b"")])
-        self.query(Protocol.LOGIN, self.login_dict(username, password))
+    def login(self, switch_mac, username, password):
+        self.query(switch_mac, Protocol.GET, [(Protocol.get_id("get_token_id"), b"")])
+        self.query(switch_mac, Protocol.LOGIN, self.login_dict(username, password))
 
-    def set(self, username, password, payload):
-        self.query(Protocol.GET, [(Protocol.get_id("get_token_id"), b"")])
+    def set(self, switch_mac, username, password, payload):
+        self.query(switch_mac, Protocol.GET, [(Protocol.get_id("get_token_id"), b"")])
         real_payload = self.login_dict(username, password)
         real_payload += payload
         header, payload = self.query(Protocol.LOGIN, real_payload)


### PR DESCRIPTION
So API can be reused for multiple switches. Also, delay creation of header until required.